### PR TITLE
Added environment variable syntax to CD

### DIFF
--- a/.github/workflows/npmCD.yml
+++ b/.github/workflows/npmCD.yml
@@ -16,9 +16,9 @@ jobs:
         id: check_merge
         run: |
           if [[ "$(git log -1 --pretty=%B "${{ github.event.pull_request.merge_commit_sha }}")" == *"Merge pull request"* ]]; then
-            echo "::set-output name=is_merged::true"
+            echo "is_merged=true" >> $GITHUB_ENV
           else
-            echo "::set-output name=is_merged::false"
+            echo "is_merged=false" >> $GITHUB_ENV
           fi
 
       - name: Setup node env
@@ -35,9 +35,9 @@ jobs:
         id: changes
         run: |
           if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.merge_commit_sha }} -- npm-package/ | grep -q .; then
-            echo "::set-output name=changes::true"
+            echo "changes=true" >> $GITHUB_ENV
           else
-            echo "::set-output name=changes::false"
+            echo "changes=false" >> $GITHUB_ENV
           fi
       - name: Deploy
         env:

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -47,6 +47,3 @@ $ npm run nextinspect
 3. Go to your Next.js application page.
 4. Open the NextInspect devtool by right clicking the page and selecting inspect. In the double right arrow dropdown to the right of the Network tab, you will be able to view your other devtool extensions.
 5. Refresh your page to view telemetry metrics.
-
-
-


### PR DESCRIPTION
environment variables instead of `set-output`

## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
Changed the npm CD workflow file to use environment variables to set step output.

**Previous behavior**
Old workflow was using deprecated syntax to set the output of steps.
